### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/examples/client_defaults/main.go
+++ b/examples/client_defaults/main.go
@@ -64,7 +64,7 @@ func main() {
 
 	if os.Getenv("POLYMARKET_CREATE_API_KEY") == "1" {
 		fmt.Println("\n2. Create API key using default auth nonce")
-		resp, err := clobClient.CreateAPIKey(ctx)
+		_, err = clobClient.CreateAPIKey(ctx)
 		if err != nil {
 			log.Fatalf("CreateAPIKey failed: %v", err)
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/GoPolymarket/polymarket-go-sdk/security/code-scanning/1](https://github.com/GoPolymarket/polymarket-go-sdk/security/code-scanning/1)

In general, avoid logging raw secrets such as API keys. If you must log something for debugging, log only non-sensitive metadata (e.g., key ID, creation time) or an obfuscated form (for example, only the last 4 characters).

For this specific code, the simplest fix without changing behavior of the API call is to stop printing the full `resp.APIKey` value. Since this is an example, we can still indicate that a key was created and, if helpful, log a partially redacted value (e.g., show only the last 4 characters) so users can distinguish between different keys. We will modify the `fmt.Printf("API Key: %s\n", resp.APIKey)` line to avoid exposing the full key, e.g. by computing a redacted string derived from `resp.APIKey` and printing only that, or by printing a generic success message.

Concretely, in `examples/client_defaults/main.go` around line 71, we will replace:

```go
fmt.Printf("API Key: %s\n", resp.APIKey)
```

with code that either (a) prints only a confirmation message like `"API key created successfully.\n"` or (b) prints an obfuscated key such as `"API Key (last 4 chars): %s\n", resp.APIKey[len(resp.APIKey)-4:]` guarded safely. This change requires no new imports and does not alter how the key is used elsewhere; it only changes what is emitted to stdout.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
