### PR TITLE
Add typed subscription for orders_matched events

### DIFF
--- a/pkg/rtds/client.go
+++ b/pkg/rtds/client.go
@@ -16,14 +16,17 @@ type Client interface {
 	SubscribeCryptoPricesStream(ctx context.Context, symbols []string) (*Stream[CryptoPriceEvent], error)
 	SubscribeChainlinkPricesStream(ctx context.Context, feeds []string) (*Stream[ChainlinkPriceEvent], error)
 	SubscribeCommentsStream(ctx context.Context, req *CommentFilter) (*Stream[CommentEvent], error)
+	SubscribeOrdersMatchedStream(ctx context.Context) (*Stream[OrdersMatchedEvent], error)
 	SubscribeRawStream(ctx context.Context, sub *Subscription) (*Stream[RtdsMessage], error)
 	SubscribeCryptoPrices(ctx context.Context, symbols []string) (<-chan CryptoPriceEvent, error)
 	SubscribeChainlinkPrices(ctx context.Context, feeds []string) (<-chan ChainlinkPriceEvent, error)
 	SubscribeComments(ctx context.Context, req *CommentFilter) (<-chan CommentEvent, error)
+	SubscribeOrdersMatched(ctx context.Context) (<-chan OrdersMatchedEvent, error)
 	SubscribeRaw(ctx context.Context, sub *Subscription) (<-chan RtdsMessage, error)
 	UnsubscribeCryptoPrices(ctx context.Context) error
 	UnsubscribeChainlinkPrices(ctx context.Context) error
 	UnsubscribeComments(ctx context.Context, commentType *CommentType) error
+	UnsubscribeOrdersMatched(ctx context.Context) error
 	UnsubscribeRaw(ctx context.Context, sub *Subscription) error
 	ConnectionState() ConnectionState
 	ConnectionStateStream(ctx context.Context) (*Stream[ConnectionStateEvent], error)

--- a/pkg/rtds/types.go
+++ b/pkg/rtds/types.go
@@ -90,6 +90,7 @@ const (
 	CryptoPrice    EventType = "crypto_prices"
 	ChainlinkPrice EventType = "crypto_prices_chainlink"
 	Comments       EventType = "comments"
+	Activity       EventType = "activity"
 )
 
 // BaseEvent carries message metadata.
@@ -148,6 +149,29 @@ type CommentEvent struct {
 	ReplyAddress     *types.Address `json:"replyAddress,omitempty"`
 	ReportCount      int64          `json:"reportCount,omitempty"`
 	UserAddress      types.Address  `json:"userAddress"`
+}
+
+// OrdersMatchedEvent is an activity stream payload for matched orders.
+type OrdersMatchedEvent struct {
+	BaseEvent
+	Asset           string  `json:"asset"`
+	Bio             string  `json:"bio"`
+	ConditionID     string  `json:"conditionId"`
+	EventSlug       string  `json:"eventSlug"`
+	Icon            string  `json:"icon"`
+	Name            string  `json:"name"`
+	Outcome         string  `json:"outcome"`
+	OutcomeIndex    int     `json:"outcomeIndex"`
+	Price           float64 `json:"price"`
+	ProfileImage    string  `json:"profileImage"`
+	ProxyWallet     string  `json:"proxyWallet"`
+	Pseudonym       string  `json:"pseudonym"`
+	Side            string  `json:"side"`
+	Size            float64 `json:"size"`
+	Slug            string  `json:"slug"`
+	Timestamp       int64   `json:"timestamp"`
+	Title           string  `json:"title"`
+	TransactionHash string  `json:"transactionHash"`
 }
 
 // CommentFilter configures the comments subscription.


### PR DESCRIPTION
## Summary
- Adds `Activity` EventType constant and `OrdersMatchedEvent` struct to `pkg/rtds/types.go`
- Adds `SubscribeOrdersMatchedStream`, `SubscribeOrdersMatched`, and `UnsubscribeOrdersMatched` to the RTDS client interface and implementation
- Follows the same pattern as existing typed subscriptions (crypto prices, chainlink, comments)

## Test plan
- [x] Verified compilation
- [x] Tested live against `wss://ws-live-data.polymarket.com/` — receives and parses `orders_matched` payloads correctly