### PR TITLE
fix: default transport client in clob.NewClient when nil

### DIFF
--- a/pkg/clob/constants.go
+++ b/pkg/clob/constants.go
@@ -1,6 +1,9 @@
 package clob
 
 const (
+	// BaseURL is the default production endpoint for the CLOB.
+	BaseURL = "https://clob.polymarket.com"
+
 	// DefaultGeoblockHost is the default host for the geoblock endpoint.
 	DefaultGeoblockHost = "https://polymarket.com"
 )

--- a/pkg/clob/impl.go
+++ b/pkg/clob/impl.go
@@ -71,6 +71,10 @@ func NewClientWithGeoblock(httpClient *transport.Client, geoblockHost string) Cl
 		geoblockHost = DefaultGeoblockHost
 	}
 
+	if httpClient == nil {
+		httpClient = transport.NewClient(nil, BaseURL)
+	}
+
 	c := &clientImpl{
 		httpClient:     httpClient,
 		cache:          newClientCache(),


### PR DESCRIPTION
## Summary
- `clob.NewClient(nil)` stored the nil `*transport.Client` directly, causing a nil pointer dereference on any API call
- `gamma.NewClient` and `data.NewClient` both create a default transport when passed nil — clob was missing this guard
- Adds `BaseURL` constant (`https://clob.polymarket.com`) and nil check in `NewClientWithGeoblock`, matching the existing pattern