### PR TITLE
fix: PriceHistoryPoint.Price type should be float64

### DIFF
--- a/pkg/clob/clobtypes/types.go
+++ b/pkg/clob/clobtypes/types.go
@@ -454,8 +454,8 @@ type (
 	}
 
 	PriceHistoryPoint struct {
-		Timestamp int64  `json:"t"`
-		Price     string `json:"p"`
+		Timestamp int64   `json:"t"`
+		Price     float64 `json:"p"`
 	}
 
 	Trade struct {


### PR DESCRIPTION
## Summary
- The `/prices-history` endpoint returns `p` as a JSON number (e.g. `0.0455`), not a string
- `PriceHistoryPoint.Price` was typed as `string`, causing `json: cannot unmarshal number into Go struct field`
- Changed to `float64` to match the actual API response