### PR TITLE
WS user trade event: Change Timestamp type from int64 to string

### DIFF
--- a/pkg/clob/ws/types.go
+++ b/pkg/clob/ws/types.go
@@ -220,7 +220,7 @@ type TradeEvent struct {
 	Price     string `json:"price"`
 	Size      string `json:"size"`
 	Side      string `json:"side"`
-	Timestamp string  `json:"timestamp"`
+	Timestamp string `json:"timestamp"`
 	ID        string `json:"id,omitempty"`
 	Market    string `json:"market,omitempty"`
 	Status    string `json:"status,omitempty"`


### PR DESCRIPTION
From https://docs.polymarket.com/market-data/websocket/user-channel 
we can see 'timestamp' in trade struct is string instead of int64