### PR TITLE
fix: use string for data/Position.EventID

### DIFF
--- a/pkg/data/impl_test.go
+++ b/pkg/data/impl_test.go
@@ -132,7 +132,7 @@ func TestClosedPositionsMissingUser(t *testing.T) {
 func TestPositionsSuccess(t *testing.T) {
 	user := common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678")
 	doer := &staticDoer{responses: map[string]string{
-		"/positions": `[{"title":"Test Market","size":"100"}]`,
+		"/positions": `[{"title":"Test Market","size":"100","eventId":"1234"}]`,
 	}}
 	client := NewClient(transport.NewClient(doer, "http://example"))
 	resp, err := client.Positions(context.Background(), &PositionsRequest{User: user})

--- a/pkg/data/types.go
+++ b/pkg/data/types.go
@@ -356,7 +356,7 @@ type (
 		Slug               string         `json:"slug"`
 		Icon               string         `json:"icon"`
 		EventSlug          string         `json:"eventSlug"`
-		EventID            *int64         `json:"eventId,omitempty"`
+		EventID            *string        `json:"eventId,omitempty"`
 		Outcome            string         `json:"outcome"`
 		OutcomeIndex       int            `json:"outcomeIndex"`
 		OppositeOutcome    string         `json:"oppositeOutcome"`


### PR DESCRIPTION
## Context

eventId field from Data API `GET /positions` endpoint is formatted as a string, which breaks this SDK.

## Fix

- Use `*string` type instead of `*int64`