### PR TITLE
 UserTotalEarnings failed: failed to unmarshal response: json: cannot…

### DIFF
--- a/pkg/clob/clobtypes/types.go
+++ b/pkg/clob/clobtypes/types.go
@@ -561,11 +561,11 @@ type (
 	}
 
 	TotalUserEarning struct {
-		Date         string `json:"date"`
-		AssetAddress string `json:"asset_address"`
-		MakerAddress string `json:"maker_address"`
-		Earnings     string `json:"earnings"`
-		AssetRate    string `json:"asset_rate"`
+		Date         string  `json:"date"`
+		AssetAddress string  `json:"asset_address"`
+		MakerAddress string  `json:"maker_address"`
+		Earnings     float64 `json:"earnings"`
+		AssetRate    float64 `json:"asset_rate"`
 	}
 
 	UserRewardsEarning struct {


### PR DESCRIPTION
… unmarshal number into Go struct field TotalUserEarning.earnings of type string