### PR TITLE
fix: support POLY_1271 order signing

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -520,3 +520,18 @@ func (s *PrivateKeySigner) SignTypedData(domain *apitypes.TypedDataDomain, types
 
 	return signature, nil
 }
+
+// SignDigest signs a 32-byte digest with the local private key.
+func (s *PrivateKeySigner) SignDigest(digest []byte) ([]byte, error) {
+	if len(digest) != 32 {
+		return nil, fmt.Errorf("digest must be 32 bytes, got %d", len(digest))
+	}
+	signature, err := crypto.Sign(digest, s.key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign hash: %w", err)
+	}
+	if signature[64] < 27 {
+		signature[64] += 27
+	}
+	return signature, nil
+}

--- a/pkg/clob/impl_orders.go
+++ b/pkg/clob/impl_orders.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/GoPolymarket/polymarket-go-sdk/v2/pkg/auth"
 	"github.com/GoPolymarket/polymarket-go-sdk/v2/pkg/clob/clobtypes"
@@ -113,6 +114,53 @@ func signOrderWithCreds(signer auth.Signer, apiKey *auth.APIKey, order *clobtype
 		return nil, fmt.Errorf("maker address cannot be zero; ensure signer is properly initialized")
 	}
 
+	sideInt := 0
+	if side == "SELL" {
+		sideInt = 1
+	}
+
+	if order.Salt.Int == nil || order.Salt.Int.Sign() == 0 {
+		var salt *big.Int
+		var err error
+		if saltGen != nil {
+			salt, err = saltGen()
+		} else {
+			salt, err = generateSalt()
+		}
+		if err != nil {
+			return nil, err
+		}
+		order.Salt = types.U256{Int: salt}
+	}
+
+	if sigTypeVal == int(auth.SignaturePoly1271) {
+		if order.Signer == (types.Address{}) || order.Signer == signer.Address() {
+			order.Signer = order.Maker
+		}
+		if order.Timestamp == 0 {
+			order.Timestamp = time.Now().UnixMilli()
+		}
+		sig, err := signPoly1271Order(signer, order)
+		if err != nil {
+			return nil, fmt.Errorf("sign POLY_1271 order: %w", err)
+		}
+
+		owner := apiKey.Key
+		if owner == "" {
+			owner = signer.Address().String()
+		}
+
+		return &clobtypes.SignedOrder{
+			Order:     *order,
+			Signature: sig,
+			Owner:     owner,
+		}, nil
+	}
+
+	if order.Signer == (types.Address{}) {
+		order.Signer = signer.Address()
+	}
+
 	domain := &apitypes.TypedDataDomain{
 		Name:              "Polymarket CTF Exchange",
 		Version:           "2",
@@ -142,37 +190,16 @@ func signOrderWithCreds(signer auth.Signer, apiKey *auth.APIKey, order *clobtype
 		},
 	}
 
-	sideInt := 0
-	if side == "SELL" {
-		sideInt = 1
-	}
-
-	if order.Salt.Int == nil || order.Salt.Int.Sign() == 0 {
-		var salt *big.Int
-		var err error
-		if saltGen != nil {
-			salt, err = saltGen()
-		} else {
-			salt, err = generateSalt()
-		}
-		if err != nil {
-			return nil, err
-		}
-		order.Salt = types.U256{Int: salt}
-	}
-
-	timestamp := order.Timestamp
-
 	message := apitypes.TypedDataMessage{
 		"salt":          (*math.HexOrDecimal256)(order.Salt.Int),
 		"maker":         order.Maker.String(),
-		"signer":        signer.Address().String(),
+		"signer":        order.Signer.String(),
 		"tokenId":       (*math.HexOrDecimal256)(order.TokenID.Int),
 		"makerAmount":   (*math.HexOrDecimal256)(order.MakerAmount.BigInt()),
 		"takerAmount":   (*math.HexOrDecimal256)(order.TakerAmount.BigInt()),
 		"side":          (*math.HexOrDecimal256)(big.NewInt(int64(sideInt))),
 		"signatureType": (*math.HexOrDecimal256)(big.NewInt(int64(sigTypeVal))),
-		"timestamp":     (*math.HexOrDecimal256)(big.NewInt(timestamp)),
+		"timestamp":     (*math.HexOrDecimal256)(big.NewInt(order.Timestamp)),
 		"metadata":      padBytes32(order.Metadata),
 		"builder":       padBytes32(order.Builder),
 	}

--- a/pkg/clob/impl_orders_test.go
+++ b/pkg/clob/impl_orders_test.go
@@ -238,6 +238,47 @@ func TestSignOrderDefaults(t *testing.T) {
 	}
 }
 
+func TestSignOrderPoly1271WrappedSignature(t *testing.T) {
+	signer, err := auth.NewPrivateKeySigner("0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80", 137)
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+	apiKey := &auth.APIKey{Key: "api-key", Secret: "secret", Passphrase: "passphrase"}
+
+	tokenID, ok := new(big.Int).SetString("1000000000000000000000000000000000000000000000000000000000000001", 10)
+	if !ok {
+		t.Fatal("invalid token id fixture")
+	}
+	funder := common.HexToAddress("0x9c90cad21cb08320Fb224EAb032dDAE311c017Ef")
+	sigType := int(auth.SignaturePoly1271)
+
+	order := &clobtypes.Order{
+		Salt:          types.U256{Int: big.NewInt(123)},
+		Maker:         funder,
+		Signer:        funder,
+		TokenID:       types.U256{Int: tokenID},
+		MakerAmount:   decimal.NewFromInt(9878920),
+		TakerAmount:   decimal.NewFromInt(20120000),
+		Expiration:    types.U256{Int: big.NewInt(1700000000)},
+		Side:          "BUY",
+		SignatureType: &sigType,
+		Timestamp:     1700000000123,
+	}
+
+	signed, err := SignOrder(signer, apiKey, order)
+	if err != nil {
+		t.Fatalf("SignOrder failed: %v", err)
+	}
+
+	expectedSignature := "0x2bc3ab0a90b33458c5dfb95b5ee707f1db927a7535e2b35b3d4f48f3bdc1e810208b6afee04445c46a09f0791522d1176eba4b0128d2d98d065780c14e68b6281c3264e159346253e26a64e00b69032db0e7d32f94628de3e6eecb50304d7af3d21c202ba2e918b30e52a234894cb7753acfda24411b5b40ea8b64f15a34ac32154f726465722875696e743235362073616c742c61646472657373206d616b65722c61646472657373207369676e65722c75696e7432353620746f6b656e49642c75696e74323536206d616b6572416d6f756e742c75696e743235362074616b6572416d6f756e742c75696e743820736964652c75696e7438207369676e6174757265547970652c75696e743235362074696d657374616d702c62797465733332206d657461646174612c62797465733332206275696c6465722900ba"
+	if signed.Signature != expectedSignature {
+		t.Fatalf("signature mismatch:\ngot  %s\nwant %s", signed.Signature, expectedSignature)
+	}
+	if signed.Order.Signer != funder {
+		t.Fatalf("signer mismatch: got %s want %s", signed.Order.Signer.Hex(), funder.Hex())
+	}
+}
+
 func TestPostOrders_BatchSizeValidation(t *testing.T) {
 	ctx := context.Background()
 	client := &clientImpl{

--- a/pkg/clob/order_builder.go
+++ b/pkg/clob/order_builder.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/shopspring/decimal"
@@ -19,12 +20,12 @@ type OrderBuilder struct {
 	client Client
 	signer auth.Signer
 
-	tokenID    string
-	side       string
-	price      decimal.Decimal
-	size       decimal.Decimal
-	tickSize   float64
-	orderType  clobtypes.OrderType
+	tokenID   string
+	side      string
+	price     decimal.Decimal
+	size      decimal.Decimal
+	tickSize  float64
+	orderType clobtypes.OrderType
 
 	// Optional overrides
 	maker         *common.Address
@@ -356,10 +357,18 @@ func (b *OrderBuilder) BuildMarketWithContext(ctx context.Context) (*clobtypes.S
 	if err != nil {
 		return nil, err
 	}
+	orderSigner := b.signer.Address()
+	timestamp := b.timestamp
+	if sigType == int(auth.SignaturePoly1271) {
+		orderSigner = maker
+		if timestamp == 0 {
+			timestamp = time.Now().UnixMilli()
+		}
+	}
 
 	order := &clobtypes.Order{
 		Salt:          types.U256{Int: salt},
-		Signer:        b.signer.Address(),
+		Signer:        orderSigner,
 		Maker:         maker,
 		TokenID:       types.U256{Int: tokenIDInt},
 		MakerAmount:   types.Decimal(makerFixed),
@@ -367,7 +376,7 @@ func (b *OrderBuilder) BuildMarketWithContext(ctx context.Context) (*clobtypes.S
 		Expiration:    types.U256{Int: big.NewInt(0)},
 		Side:          side,
 		SignatureType: &sigType,
-		Timestamp:     b.timestamp,
+		Timestamp:     timestamp,
 		Metadata:      b.metadata,
 		Builder:       b.builder,
 	}
@@ -465,6 +474,14 @@ func (b *OrderBuilder) buildLimit(ctx context.Context) (*clobtypes.Order, error)
 	if err != nil {
 		return nil, err
 	}
+	orderSigner := b.signer.Address()
+	timestamp := b.timestamp
+	if sigType == int(auth.SignaturePoly1271) {
+		orderSigner = maker
+		if timestamp == 0 {
+			timestamp = time.Now().UnixMilli()
+		}
+	}
 
 	expiration := big.NewInt(0)
 	if b.expiration != nil {
@@ -476,7 +493,7 @@ func (b *OrderBuilder) buildLimit(ctx context.Context) (*clobtypes.Order, error)
 
 	return &clobtypes.Order{
 		Salt:          types.U256{Int: salt},
-		Signer:        b.signer.Address(),
+		Signer:        orderSigner,
 		Maker:         maker,
 		TokenID:       types.U256{Int: tokenIDInt},
 		MakerAmount:   types.Decimal(makerFixed),
@@ -484,7 +501,7 @@ func (b *OrderBuilder) buildLimit(ctx context.Context) (*clobtypes.Order, error)
 		Expiration:    types.U256{Int: expiration},
 		Side:          side,
 		SignatureType: &sigType,
-		Timestamp:     b.timestamp,
+		Timestamp:     timestamp,
 		Metadata:      b.metadata,
 		Builder:       b.builder,
 	}, nil

--- a/pkg/clob/order_builder_test.go
+++ b/pkg/clob/order_builder_test.go
@@ -267,6 +267,42 @@ func TestOrderBuilderDefaultsFromClient(t *testing.T) {
 	}
 }
 
+func TestOrderBuilderPoly1271UsesFunderAsSigner(t *testing.T) {
+	stub := newStubClient()
+	stub.tickSize = 0.01
+	stub.feeRate = 0
+
+	signer := mustSigner(t)
+	funder := common.HexToAddress("0x9c90cad21cb08320Fb224EAb032dDAE311c017Ef")
+	stub.clientImpl.signatureType = auth.SignaturePoly1271
+	stub.clientImpl.funder = &funder
+	stub.clientImpl.saltGenerator = func() (*big.Int, error) {
+		return big.NewInt(42), nil
+	}
+
+	signable, err := NewOrderBuilder(stub, signer).
+		TokenID("123").
+		Side("BUY").
+		Price(0.5).
+		Size(10).
+		BuildSignableWithContext(context.Background())
+	if err != nil {
+		t.Fatalf("BuildSignable failed: %v", err)
+	}
+	if signable.Order.SignatureType == nil || *signable.Order.SignatureType != int(auth.SignaturePoly1271) {
+		t.Fatalf("signature type mismatch: %+v", signable.Order.SignatureType)
+	}
+	if signable.Order.Maker != funder {
+		t.Fatalf("maker mismatch: got %s want %s", signable.Order.Maker.Hex(), funder.Hex())
+	}
+	if signable.Order.Signer != funder {
+		t.Fatalf("signer mismatch: got %s want %s", signable.Order.Signer.Hex(), funder.Hex())
+	}
+	if signable.Order.Timestamp == 0 {
+		t.Fatal("expected POLY_1271 builder to set order timestamp")
+	}
+}
+
 func TestOrderBuilderFunderRequiresSignature(t *testing.T) {
 	stub := newStubClient()
 	stub.tickSize = 0.01

--- a/pkg/clob/order_payload.go
+++ b/pkg/clob/order_payload.go
@@ -1,13 +1,13 @@
 package clob
 
-import "github.com/GoPolymarket/polymarket-go-sdk/v2/pkg/clob/clobtypes"
-
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/GoPolymarket/polymarket-go-sdk/v2/pkg/clob/clobtypes"
 	"github.com/GoPolymarket/polymarket-go-sdk/v2/pkg/types"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 func buildOrderPayload(order *clobtypes.SignedOrder) (map[string]interface{}, error) {
@@ -33,6 +33,8 @@ func buildOrderPayload(order *clobtypes.SignedOrder) (map[string]interface{}, er
 	}
 	if order.DeferExec != nil {
 		payload["deferExec"] = *order.DeferExec
+	} else if isPoly1271SignedOrder(order) {
+		payload["deferExec"] = false
 	}
 	return payload, nil
 }
@@ -74,8 +76,15 @@ func orderWithSignature(order *clobtypes.SignedOrder) (map[string]interface{}, e
 		return nil, fmt.Errorf("invalid order side %q", order.Order.Side)
 	}
 
+	salt := interface{}(u256String(order.Order.Salt))
+	timestamp := interface{}(order.Order.Timestamp)
+	if sigType == 3 {
+		salt = json.Number(u256String(order.Order.Salt))
+		timestamp = fmt.Sprintf("%d", order.Order.Timestamp)
+	}
+
 	payload := map[string]interface{}{
-		"salt":          u256String(order.Order.Salt),
+		"salt":          salt,
 		"maker":         order.Order.Maker.Hex(),
 		"signer":        order.Order.Signer.Hex(),
 		"tokenId":       u256String(order.Order.TokenID),
@@ -88,10 +97,14 @@ func orderWithSignature(order *clobtypes.SignedOrder) (map[string]interface{}, e
 	}
 
 	// V2 fields - always include to match EIP-712 signed values
-	payload["timestamp"] = order.Order.Timestamp
+	payload["timestamp"] = timestamp
 	payload["metadata"] = padBytes32(order.Order.Metadata)
 	payload["builder"] = padBytes32(order.Order.Builder)
 	return payload, nil
+}
+
+func isPoly1271SignedOrder(order *clobtypes.SignedOrder) bool {
+	return order != nil && order.Order.SignatureType != nil && *order.Order.SignatureType == 3
 }
 
 func u256String(value types.U256) string {

--- a/pkg/clob/order_payload_test.go
+++ b/pkg/clob/order_payload_test.go
@@ -1,7 +1,7 @@
 package clob
 
 import (
-	"github.com/GoPolymarket/polymarket-go-sdk/v2/pkg/clob/clobtypes"
+	"encoding/json"
 	"math/big"
 	"strings"
 	"testing"
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/shopspring/decimal"
 
+	"github.com/GoPolymarket/polymarket-go-sdk/v2/pkg/clob/clobtypes"
 	"github.com/GoPolymarket/polymarket-go-sdk/v2/pkg/types"
 )
 
@@ -56,6 +57,45 @@ func TestBuildOrderPayloadCasingAndOptions(t *testing.T) {
 	}
 	if orderMap["signature"] != "0xsig" {
 		t.Fatalf("signature mismatch: got %v", orderMap["signature"])
+	}
+}
+
+func TestBuildOrderPayloadPoly1271Compatibility(t *testing.T) {
+	sigType := 3
+	order := clobtypes.SignedOrder{
+		Order: clobtypes.Order{
+			Salt:          types.U256{Int: big.NewInt(123)},
+			Maker:         common.HexToAddress("0x9c90cad21cb08320Fb224EAb032dDAE311c017Ef"),
+			Signer:        common.HexToAddress("0x9c90cad21cb08320Fb224EAb032dDAE311c017Ef"),
+			TokenID:       types.U256{Int: big.NewInt(123)},
+			MakerAmount:   decimal.NewFromInt(100),
+			TakerAmount:   decimal.NewFromInt(50),
+			Side:          "BUY",
+			Expiration:    types.U256{Int: big.NewInt(0)},
+			SignatureType: &sigType,
+			Timestamp:     1700000000123,
+		},
+		Signature: "0xsig",
+		Owner:     "builder-owner",
+		OrderType: clobtypes.OrderTypeGTC,
+	}
+
+	payload, err := buildOrderPayload(&order)
+	if err != nil {
+		t.Fatalf("buildOrderPayload failed: %v", err)
+	}
+	if got := payload["deferExec"]; got != false {
+		t.Fatalf("deferExec mismatch: got %v", got)
+	}
+	orderMap, ok := payload["order"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("order payload missing order map")
+	}
+	if got := orderMap["salt"]; got != json.Number("123") {
+		t.Fatalf("salt mismatch: got %#v", got)
+	}
+	if got := orderMap["timestamp"]; got != "1700000000123" {
+		t.Fatalf("timestamp mismatch: got %#v", got)
 	}
 }
 

--- a/pkg/clob/poly1271.go
+++ b/pkg/clob/poly1271.go
@@ -1,0 +1,181 @@
+package clob
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/GoPolymarket/polymarket-go-sdk/v2/pkg/auth"
+	"github.com/GoPolymarket/polymarket-go-sdk/v2/pkg/clob/clobtypes"
+)
+
+const (
+	poly1271ExchangeV2Address     = "0xE111180000d2663C0091e4f400237545B87B996B"
+	poly1271Bytes32Zero           = "0x0000000000000000000000000000000000000000000000000000000000000000"
+	poly1271EIP712DomainType      = "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+	poly1271OrderType             = "Order(uint256 salt,address maker,address signer,uint256 tokenId,uint256 makerAmount,uint256 takerAmount,uint8 side,uint8 signatureType,uint256 timestamp,bytes32 metadata,bytes32 builder)"
+	poly1271TypedDataSignType     = "TypedDataSign(Order contents,string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)" + poly1271OrderType
+	poly1271ExchangeDomainName    = "Polymarket CTF Exchange"
+	poly1271ExchangeDomainVersion = "2"
+	poly1271DepositWalletName     = "DepositWallet"
+	poly1271DepositWalletVersion  = "1"
+)
+
+type digestSigner interface {
+	SignDigest([]byte) ([]byte, error)
+}
+
+type poly1271OrderForHash struct {
+	Salt          *big.Int
+	Maker         common.Address
+	Signer        common.Address
+	TokenID       *big.Int
+	MakerAmount   *big.Int
+	TakerAmount   *big.Int
+	Side          *big.Int
+	SignatureType *big.Int
+	Timestamp     *big.Int
+	Metadata      string
+	Builder       string
+}
+
+func signPoly1271Order(signer auth.Signer, order *clobtypes.Order) (string, error) {
+	digestSigner, ok := signer.(digestSigner)
+	if !ok {
+		return "", fmt.Errorf("POLY_1271 signing requires a signer that can sign raw digests")
+	}
+
+	side, err := poly1271Side(order.Side)
+	if err != nil {
+		return "", err
+	}
+	sigType := int(auth.SignaturePoly1271)
+	if order.SignatureType != nil {
+		sigType = *order.SignatureType
+	}
+
+	orderForHash := poly1271OrderForHash{
+		Salt:          order.Salt.Int,
+		Maker:         order.Maker,
+		Signer:        order.Signer,
+		TokenID:       order.TokenID.Int,
+		MakerAmount:   order.MakerAmount.BigInt(),
+		TakerAmount:   order.TakerAmount.BigInt(),
+		Side:          big.NewInt(int64(side)),
+		SignatureType: big.NewInt(int64(sigType)),
+		Timestamp:     big.NewInt(order.Timestamp),
+		Metadata:      padBytes32(order.Metadata),
+		Builder:       padBytes32(order.Builder),
+	}
+
+	domainSeparator := poly1271ExchangeDomainSeparator(common.HexToAddress(poly1271ExchangeV2Address), signer.ChainID().Int64())
+	contentsHash, err := poly1271OrderStructHash(orderForHash)
+	if err != nil {
+		return "", err
+	}
+	walletSalt, err := poly1271ABIHexBytes32(poly1271Bytes32Zero)
+	if err != nil {
+		return "", err
+	}
+	typedDataSignHash := crypto.Keccak256(
+		poly1271ABIBytes32(poly1271TypedDataSignType),
+		contentsHash,
+		poly1271ABIBytes32(poly1271DepositWalletName),
+		poly1271ABIBytes32(poly1271DepositWalletVersion),
+		poly1271ABIUint(signer.ChainID()),
+		poly1271ABIAddress(order.Signer),
+		walletSalt,
+	)
+	digest := crypto.Keccak256(append(append([]byte{0x19, 0x01}, domainSeparator...), typedDataSignHash...))
+	innerSignature, err := digestSigner.SignDigest(digest)
+	if err != nil {
+		return "", err
+	}
+	return wrapPoly1271Signature(innerSignature, domainSeparator, contentsHash), nil
+}
+
+func poly1271ExchangeDomainSeparator(exchange common.Address, chainID int64) []byte {
+	return crypto.Keccak256(
+		poly1271ABIBytes32(poly1271EIP712DomainType),
+		poly1271ABIBytes32(poly1271ExchangeDomainName),
+		poly1271ABIBytes32(poly1271ExchangeDomainVersion),
+		poly1271ABIUint(big.NewInt(chainID)),
+		poly1271ABIAddress(exchange),
+	)
+}
+
+func poly1271OrderStructHash(order poly1271OrderForHash) ([]byte, error) {
+	metadata, err := poly1271ABIHexBytes32(order.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	builder, err := poly1271ABIHexBytes32(order.Builder)
+	if err != nil {
+		return nil, err
+	}
+	return crypto.Keccak256(
+		poly1271ABIBytes32(poly1271OrderType),
+		poly1271ABIUint(order.Salt),
+		poly1271ABIAddress(order.Maker),
+		poly1271ABIAddress(order.Signer),
+		poly1271ABIUint(order.TokenID),
+		poly1271ABIUint(order.MakerAmount),
+		poly1271ABIUint(order.TakerAmount),
+		poly1271ABIUint(order.Side),
+		poly1271ABIUint(order.SignatureType),
+		poly1271ABIUint(order.Timestamp),
+		metadata,
+		builder,
+	), nil
+}
+
+func wrapPoly1271Signature(innerSignature, domainSeparator, contentsHash []byte) string {
+	out := make([]byte, 0, len(innerSignature)+len(domainSeparator)+len(contentsHash)+len(poly1271OrderType)+2)
+	out = append(out, innerSignature...)
+	out = append(out, domainSeparator...)
+	out = append(out, contentsHash...)
+	out = append(out, []byte(poly1271OrderType)...)
+	length := make([]byte, 2)
+	binary.BigEndian.PutUint16(length, uint16(len(poly1271OrderType)))
+	out = append(out, length...)
+	return "0x" + hex.EncodeToString(out)
+}
+
+func poly1271ABIBytes32(value string) []byte {
+	return crypto.Keccak256([]byte(value))
+}
+
+func poly1271ABIUint(value *big.Int) []byte {
+	return common.LeftPadBytes(value.Bytes(), 32)
+}
+
+func poly1271ABIAddress(value common.Address) []byte {
+	return common.LeftPadBytes(value.Bytes(), 32)
+}
+
+func poly1271ABIHexBytes32(value string) ([]byte, error) {
+	raw, err := hex.DecodeString(strings.TrimPrefix(value, "0x"))
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) != 32 {
+		return nil, fmt.Errorf("expected bytes32, got %d bytes", len(raw))
+	}
+	return raw, nil
+}
+
+func poly1271Side(side string) (int, error) {
+	switch strings.ToUpper(strings.TrimSpace(side)) {
+	case "BUY":
+		return 0, nil
+	case "SELL":
+		return 1, nil
+	default:
+		return 0, fmt.Errorf("order side must be BUY or SELL, got %q", side)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses #55.

This adds POLY_1271/type 3 order signing support for CLOB orders.

The SDK previously signed type 3 orders through the normal EIP-712 path and kept the EOA as the order `signer`. For deposit-wallet orders, the order signer needs to be the funder/deposit wallet and the signature needs to be wrapped using the POLY_1271 flow.

## Changes

- Add raw digest signing support for `PrivateKeySigner`
- Add POLY_1271 wrapped order signing
- Use funder/deposit wallet as order signer for type 3 orders
- Set millisecond timestamp for type 3 orders when missing
- Send type 3 payload with compatible `deferExec`, `salt`, and `timestamp` fields
- Add regression tests for builder, signing, and payload format

## Verification

- `go test ./...`
- `go vet ./...`

Also tested against CLOB with a live order create/cancel flow.